### PR TITLE
feat(subscription): support graphql-transport-ws protocol

### DIFF
--- a/docs/_includes/subscriptions.rst
+++ b/docs/_includes/subscriptions.rst
@@ -34,11 +34,12 @@ stdout when either :attr:`aiographql.client.GraphQLSubscriptionEventType.DATA` o
     # unsubscribe
     await subscription.unsubscribe_and_wait()
 
-.. hint:: In the case you want to specify the GraphQL over WebSocket sub-protocol to use,
-    you may do so by setting :attr:`aiographql.client.GraphQLSubscription.protocols`.
-    For example, :code:`await client.subscribe(..., protocols="graphql-ws")`. This is
-    required for certain server implementations like `Apollo Server <https://www.apollographql.com/docs/apollo-server/>`_
-    as it supports multiple implementations.
+.. hint:: By default, subscriptions negotiate the modern standard :code:`"graphql-transport-ws"`
+    sub-protocol and fall back to legacy :code:`"graphql-ws"`. In the case you want to restrict
+    the GraphQL over WebSocket sub-protocol to use, you may do so by setting
+    :attr:`aiographql.client.GraphQLSubscription.protocols`.
+    For example, :code:`await client.subscribe(..., protocols="graphql-transport-ws")` or
+    :code:`await client.subscribe(..., protocols="graphql-ws")`.
 
     Similarly, if your server requires additional fields in the `connection_init` payload
     (for example, an `authToken` or `headers`), you can provide them using the

--- a/src/aiographql/client/__init__.py
+++ b/src/aiographql/client/__init__.py
@@ -15,6 +15,8 @@ from aiographql.client.exceptions import GraphQLIntrospectionException
 from aiographql.client.exceptions import GraphQLRequestException
 from aiographql.client.request import GraphQLRequest
 from aiographql.client.response import GraphQLResponse
+from aiographql.client.subscription import GRAPHQL_TRANSPORT_WS_PROTOCOL
+from aiographql.client.subscription import GRAPHQL_WS_PROTOCOL
 from aiographql.client.subscription import GraphQLSubscription
 from aiographql.client.subscription import GraphQLSubscriptionEvent
 from aiographql.client.subscription import GraphQLSubscriptionEventType
@@ -39,6 +41,8 @@ def __getattr__(name: str) -> Any:
 
 
 __all__ = [
+    "GRAPHQL_TRANSPORT_WS_PROTOCOL",
+    "GRAPHQL_WS_PROTOCOL",
     "AiohttpTransport",
     "DefaultGraphQLCodec",
     "GraphQLClient",

--- a/src/aiographql/client/client.py
+++ b/src/aiographql/client/client.py
@@ -18,6 +18,8 @@ from aiographql.client.exceptions import GraphQLIntrospectionException
 from aiographql.client.request import GraphQLRequest
 from aiographql.client.serializer import DefaultSerializer
 from aiographql.client.serializer import GraphQLSerializer
+from aiographql.client.subscription import GRAPHQL_TRANSPORT_WS_PROTOCOL
+from aiographql.client.subscription import GRAPHQL_WS_PROTOCOL
 from aiographql.client.subscription import CallbacksType
 from aiographql.client.subscription import GraphQLSubscription
 from aiographql.client.subscription import GraphQLSubscriptionEventType
@@ -439,7 +441,10 @@ class GraphQLClient:
         on_error: CallbackType | None = None,
         session: GraphQLSession | None = None,
         wait: bool = False,
-        protocols: str | Iterable[str] = ("graphql-ws",),
+        protocols: str | Iterable[str] = (
+            GRAPHQL_TRANSPORT_WS_PROTOCOL,
+            GRAPHQL_WS_PROTOCOL,
+        ),
         connection_init_payload: dict[str, Any] | None = None,
         transport: GraphQLSubscriptionTransport | None = None,
     ) -> GraphQLSubscription:

--- a/src/aiographql/client/subscription.py
+++ b/src/aiographql/client/subscription.py
@@ -31,6 +31,10 @@ from aiographql.client.response import GraphQLResponse
 from aiographql.client.transport.resolver import get_default_subscription_transport
 
 
+GRAPHQL_TRANSPORT_WS_PROTOCOL = "graphql-transport-ws"
+GRAPHQL_WS_PROTOCOL = "graphql-ws"
+
+
 class GraphQLSubscriptionEventType(Enum):
     """
     GraphQL Subscription Event Types
@@ -46,6 +50,10 @@ class GraphQLSubscriptionEventType(Enum):
     COMPLETE = "complete"
     STOP = "stop"
     KEEP_ALIVE = "ka"
+    SUBSCRIBE = "subscribe"
+    NEXT = "next"
+    PING = "ping"
+    PONG = "pong"
 
 
 if TYPE_CHECKING:
@@ -87,9 +95,15 @@ class GraphQLSubscriptionEvent(GraphQLBaseResponse):
         if payload is not None:
             if self.type in (
                 GraphQLSubscriptionEventType.DATA,
+                GraphQLSubscriptionEventType.NEXT,
                 GraphQLSubscriptionEventType.ERROR,
-            ) and isinstance(payload, dict):
-                return GraphQLResponse(request=self.request, json=payload)
+            ):
+                if isinstance(payload, dict):
+                    return GraphQLResponse(request=self.request, json=payload)
+                if isinstance(payload, list):
+                    return GraphQLResponse(
+                        request=self.request, json={"errors": payload}
+                    )
             return cast("str", payload)
         return None
 
@@ -132,7 +146,10 @@ class GraphQLSubscription(GraphQLRequestContainer):
         ]
     )
     protocols: str | Iterable[str] = dataclasses.field(
-        default_factory=lambda: ("graphql-ws",)
+        default_factory=lambda: (
+            GRAPHQL_TRANSPORT_WS_PROTOCOL,
+            GRAPHQL_WS_PROTOCOL,
+        )
     )
     connection_init_payload: dict[str, Any] | None = dataclasses.field(default=None)
     serializer: GraphQLSerializer | None = dataclasses.field(default=None)
@@ -157,6 +174,8 @@ class GraphQLSubscription(GraphQLRequestContainer):
 
         if isinstance(self.protocols, str):
             object.__setattr__(self, "protocols", (self.protocols,))
+        else:
+            object.__setattr__(self, "protocols", tuple(self.protocols))
 
         if self.callbacks is None:
             object.__setattr__(self, "callbacks", CallbackRegistry())
@@ -197,28 +216,77 @@ class GraphQLSubscription(GraphQLRequestContainer):
             "payload": payload,
         }
 
-    def connection_start_request(self) -> dict[str, Any]:
+    def connection_start_request(self, protocol: str | None = None) -> dict[str, Any]:
         """
         Connection start payload to use when starting a subscription.
 
-        :return: Connection start payload.
+        :param protocol: Negotiated or active subprotocol.
+        :return: Connection start / subscribe payload.
         """
         payload: dict[str, Any] = {}
         if not isinstance(self.request, str):
             payload = self.request.payload()
+
+        actual_protocol = protocol
+        if actual_protocol is None:
+            if GRAPHQL_WS_PROTOCOL in self.protocols:
+                actual_protocol = GRAPHQL_WS_PROTOCOL
+            else:
+                actual_protocol = GRAPHQL_TRANSPORT_WS_PROTOCOL
+
+        if actual_protocol == GRAPHQL_WS_PROTOCOL:
+            return {
+                "id": self.id,
+                "type": GraphQLSubscriptionEventType.START.value,
+                "payload": payload,
+            }
         return {
             "id": self.id,
-            "type": GraphQLSubscriptionEventType.START.value,
+            "type": GraphQLSubscriptionEventType.SUBSCRIBE.value,
             "payload": payload,
         }
 
-    def connection_stop_request(self) -> dict[str, Any]:
+    def connection_stop_request(self, protocol: str | None = None) -> dict[str, Any]:
         """
         Connection stop payload to use when stopping a subscription.
 
-        :return: Connection stop payload.
+        :param protocol: Negotiated or active subprotocol.
+        :return: Connection stop / complete payload.
         """
-        return {"id": self.id, "type": GraphQLSubscriptionEventType.STOP.value}
+        actual_protocol = protocol
+        if actual_protocol is None:
+            if GRAPHQL_WS_PROTOCOL in self.protocols:
+                actual_protocol = GRAPHQL_WS_PROTOCOL
+            else:
+                actual_protocol = GRAPHQL_TRANSPORT_WS_PROTOCOL
+
+        if actual_protocol == GRAPHQL_WS_PROTOCOL:
+            return {"id": self.id, "type": GraphQLSubscriptionEventType.STOP.value}
+        return {"id": self.id, "type": GraphQLSubscriptionEventType.COMPLETE.value}
+
+    def connection_pong_request(self, payload: Any = None) -> dict[str, Any]:
+        """
+        Connection pong payload to respond to a server ping.
+
+        :param payload: Optional payload matching the ping message.
+        :return: Pong payload.
+        """
+        msg: dict[str, Any] = {"type": GraphQLSubscriptionEventType.PONG.value}
+        if payload is not None:
+            msg["payload"] = payload
+        return msg
+
+    def connection_ping_request(self, payload: Any = None) -> dict[str, Any]:
+        """
+        Connection ping payload to send a heartbeat to the server.
+
+        :param payload: Optional payload.
+        :return: Ping payload.
+        """
+        msg: dict[str, Any] = {"type": GraphQLSubscriptionEventType.PING.value}
+        if payload is not None:
+            msg["payload"] = payload
+        return msg
 
     def is_stop_event(self, event: GraphQLSubscriptionEvent) -> bool:
         """
@@ -241,6 +309,14 @@ class GraphQLSubscription(GraphQLRequestContainer):
             and isinstance(self.callbacks, CallbackRegistry)
         ):
             self.callbacks.dispatch(event.type, event)
+            if event.type == GraphQLSubscriptionEventType.NEXT:
+                self.callbacks.dispatch(GraphQLSubscriptionEventType.DATA, event)
+            elif event.type == GraphQLSubscriptionEventType.DATA:
+                self.callbacks.dispatch(GraphQLSubscriptionEventType.NEXT, event)
+            elif event.type == GraphQLSubscriptionEventType.PING:
+                self.callbacks.dispatch(GraphQLSubscriptionEventType.KEEP_ALIVE, event)
+            elif event.type == GraphQLSubscriptionEventType.KEEP_ALIVE:
+                self.callbacks.dispatch(GraphQLSubscriptionEventType.PING, event)
 
     async def _websocket_connect(
         self,
@@ -266,15 +342,22 @@ class GraphQLSubscription(GraphQLRequestContainer):
 
             object.__setattr__(self, "serializer", DefaultSerializer())
 
-        ws = await transport.subscribe(
-            endpoint=endpoint,
-            request=cast("GraphQLRequest", self.request),
-            serializer=cast("GraphQLSerializer", self.serializer),
-            protocols=self.protocols,
-            session=session,
-        )
-
         try:
+            ws = await transport.subscribe(
+                endpoint=endpoint,
+                request=cast("GraphQLRequest", self.request),
+                serializer=cast("GraphQLSerializer", self.serializer),
+                protocols=self.protocols,
+                session=session,
+            )
+
+            negotiated_protocol = getattr(ws, "subprotocol", None)
+            if negotiated_protocol is None:
+                if GRAPHQL_WS_PROTOCOL in self.protocols:
+                    negotiated_protocol = GRAPHQL_WS_PROTOCOL
+                else:
+                    negotiated_protocol = GRAPHQL_TRANSPORT_WS_PROTOCOL
+
             async with ws:
 
                 def _serialize(value: Any) -> str:
@@ -294,7 +377,11 @@ class GraphQLSubscription(GraphQLRequestContainer):
                         GraphQLSubscriptionEventType.CONNECTION_ACK,
                         SimpleTriggerCallback(
                             function=ws.send_str,
-                            data=_serialize(self.connection_start_request()),
+                            data=_serialize(
+                                self.connection_start_request(
+                                    protocol=negotiated_protocol
+                                )
+                            ),
                         ),
                     )
 
@@ -305,12 +392,25 @@ class GraphQLSubscription(GraphQLRequestContainer):
                             request=self.request,
                             json=cast("GraphQLSerializer", self.serializer).loads(data),
                         )
+
+                        if event.type == GraphQLSubscriptionEventType.PING:
+                            ping_payload = event.json.get("payload")
+                            await ws.send_str(
+                                _serialize(
+                                    self.connection_pong_request(payload=ping_payload)
+                                )
+                            )
+
                         await self.handle(event=event)
 
                         if self.is_stop_event(event):
                             break
                 except (asyncio.CancelledError, KeyboardInterrupt):
-                    await ws.send_str(_serialize(self.connection_stop_request()))
+                    await ws.send_str(
+                        _serialize(
+                            self.connection_stop_request(protocol=negotiated_protocol)
+                        )
+                    )
         finally:
             await transport.close()
 

--- a/src/aiographql/client/transport/aiohttp.py
+++ b/src/aiographql/client/transport/aiohttp.py
@@ -228,6 +228,10 @@ class AiohttpWebSocketResponse(GraphQLWebSocketResponse):
     def __init__(self, ws: aiohttp.ClientWebSocketResponse) -> None:
         self.ws = ws
 
+    @property
+    def subprotocol(self) -> str | None:
+        return self.ws.protocol
+
     async def __aenter__(self) -> AiohttpWebSocketResponse:
         # aiohttp.ClientWebSocketResponse does not have __aenter__, so return self
         return self

--- a/src/aiographql/client/transport/base.py
+++ b/src/aiographql/client/transport/base.py
@@ -61,6 +61,9 @@ class GraphQLWebSocketResponse(Protocol):
 
     async def __anext__(self) -> Any: ...
 
+    @property
+    def subprotocol(self) -> str | None: ...
+
 
 @runtime_checkable
 class GraphQLSubscriptionTransport(Protocol):

--- a/src/aiographql/client/transport/websocket.py
+++ b/src/aiographql/client/transport/websocket.py
@@ -78,6 +78,10 @@ class WebsocketResponse(GraphQLWebSocketResponse):
     def __init__(self, ws: ClientConnection) -> None:
         self.ws = ws
 
+    @property
+    def subprotocol(self) -> str | None:
+        return getattr(self.ws, "subprotocol", None)
+
     async def __aenter__(self) -> WebsocketResponse:
         return self
 

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
@@ -165,6 +167,28 @@ async def test_subscription_integration_strawberry(
         if isinstance(payload, GraphQLResponse):
             results.append(payload.data["count"])
 
+    # Default protocols will negotiate graphql-transport-ws
+    await strawberry_client.subscribe(
+        "subscription { count(target: 3) }",  # type: ignore[arg-type]
+        on_data=on_data,
+        wait=True,
+    )
+    assert results == [0, 1, 2]
+
+
+@pytest.mark.strawberry
+@pytest.mark.asyncio
+async def test_subscription_integration_strawberry_legacy(
+    strawberry_client: GraphQLClient,
+) -> None:
+    results = []
+
+    async def on_data(event: GraphQLSubscriptionEvent) -> None:
+        payload = event.payload
+        if isinstance(payload, GraphQLResponse):
+            results.append(payload.data["count"])
+
+    # Explicit legacy protocol
     await strawberry_client.subscribe(
         "subscription { count(target: 3) }",  # type: ignore[arg-type]
         on_data=on_data,
@@ -187,6 +211,58 @@ async def test_subscription_handle_mismatch_id(ws_message_data: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_subscription_handle_next_dispatches_data_callback() -> None:
+    req = GraphQLRequest(query="{ city { name } }")
+    sub = GraphQLSubscription(request=req)
+    received_data_events: list[GraphQLSubscriptionEvent] = []
+    received_next_events: list[GraphQLSubscriptionEvent] = []
+
+    async def on_data(event: GraphQLSubscriptionEvent) -> None:
+        received_data_events.append(event)
+
+    async def on_next(event: GraphQLSubscriptionEvent) -> None:
+        received_next_events.append(event)
+
+    sub.callbacks.register(GraphQLSubscriptionEventType.DATA, on_data)  # type: ignore[union-attr]
+    sub.callbacks.register(GraphQLSubscriptionEventType.NEXT, on_next)  # type: ignore[union-attr]
+
+    event = GraphQLSubscriptionEvent(
+        request=req,
+        json={"id": sub.id, "type": "next", "payload": {"data": {"count": 1}}},
+    )
+    await sub.handle(event)
+    await asyncio.sleep(0.01)
+    assert received_data_events == [event]
+    assert received_next_events == [event]
+
+
+@pytest.mark.asyncio
+async def test_subscription_handle_ping_dispatches_keep_alive_callback() -> None:
+    req = GraphQLRequest(query="{ city { name } }")
+    sub = GraphQLSubscription(request=req)
+    received_ka_events: list[GraphQLSubscriptionEvent] = []
+    received_ping_events: list[GraphQLSubscriptionEvent] = []
+
+    async def on_ka(event: GraphQLSubscriptionEvent) -> None:
+        received_ka_events.append(event)
+
+    async def on_ping(event: GraphQLSubscriptionEvent) -> None:
+        received_ping_events.append(event)
+
+    sub.callbacks.register(GraphQLSubscriptionEventType.KEEP_ALIVE, on_ka)  # type: ignore[union-attr]
+    sub.callbacks.register(GraphQLSubscriptionEventType.PING, on_ping)  # type: ignore[union-attr]
+
+    event = GraphQLSubscriptionEvent(
+        request=req,
+        json={"type": "ping", "payload": {"extra": "data"}},
+    )
+    await sub.handle(event)
+    await asyncio.sleep(0.01)
+    assert received_ka_events == [event]
+    assert received_ping_events == [event]
+
+
+@pytest.mark.asyncio
 async def test_subscription_serializer_lazy_init() -> None:
     sub = GraphQLSubscription(request="{ city { name } }")
     object.__setattr__(sub, "serializer", None)
@@ -202,6 +278,7 @@ async def test_subscription_serializer_lazy_init() -> None:
         return mock_ws
 
     mock_ws.__aenter__ = mock_ws_aenter
+    mock_ws.subprotocol = "graphql-transport-ws"
 
     mock_transport = MagicMock()
     mock_transport.subscribe.return_value = mock_ws
@@ -283,10 +360,129 @@ async def test_subscription_routing_aiohttp(mocker: MockerFixture) -> None:
         assert kwargs["session"] is aiohttp_session
 
 
-def test_subscription_connection_stop_request() -> None:
+def test_subscription_connection_start_request_negotiated() -> None:
+    subscription = GraphQLSubscription(
+        request=GraphQLRequest(query="{ city { name } }")
+    )
+    start_request = subscription.connection_start_request(
+        protocol="graphql-transport-ws"
+    )
+    assert start_request == {
+        "id": subscription.id,
+        "type": GraphQLSubscriptionEventType.SUBSCRIBE.value,
+        "payload": {"query": "{ city { name } }", "variables": {}},
+    }
+
+
+def test_subscription_connection_start_request_unnegotiated_fallback() -> None:
+    subscription = GraphQLSubscription(
+        request=GraphQLRequest(query="{ city { name } }")
+    )
+    start_request = subscription.connection_start_request()
+    assert start_request == {
+        "id": subscription.id,
+        "type": GraphQLSubscriptionEventType.START.value,
+        "payload": {"query": "{ city { name } }", "variables": {}},
+    }
+
+
+def test_subscription_connection_start_request_legacy() -> None:
+    subscription = GraphQLSubscription(
+        request=GraphQLRequest(query="{ city { name } }"),
+        protocols=["graphql-ws"],
+    )
+    start_request = subscription.connection_start_request()
+    assert start_request == {
+        "id": subscription.id,
+        "type": GraphQLSubscriptionEventType.START.value,
+        "payload": {"query": "{ city { name } }", "variables": {}},
+    }
+
+
+def test_subscription_connection_stop_request_negotiated() -> None:
+    subscription = GraphQLSubscription(request=GraphQLRequest(query="{}"))
+    stop_request = subscription.connection_stop_request(protocol="graphql-transport-ws")
+    assert stop_request == {
+        "id": subscription.id,
+        "type": GraphQLSubscriptionEventType.COMPLETE.value,
+    }
+
+
+def test_subscription_connection_stop_request_unnegotiated_fallback() -> None:
     subscription = GraphQLSubscription(request=GraphQLRequest(query="{}"))
     stop_request = subscription.connection_stop_request()
     assert stop_request == {
         "id": subscription.id,
         "type": GraphQLSubscriptionEventType.STOP.value,
     }
+
+
+def test_subscription_connection_stop_request_legacy() -> None:
+    subscription = GraphQLSubscription(
+        request=GraphQLRequest(query="{}"), protocols=["graphql-ws"]
+    )
+    stop_request = subscription.connection_stop_request()
+    assert stop_request == {
+        "id": subscription.id,
+        "type": GraphQLSubscriptionEventType.STOP.value,
+    }
+
+
+def test_subscription_connection_ping_pong_request() -> None:
+    subscription = GraphQLSubscription(request=GraphQLRequest(query="{}"))
+    assert subscription.connection_ping_request() == {"type": "ping"}
+    assert subscription.connection_ping_request(payload={"key": "val"}) == {
+        "type": "ping",
+        "payload": {"key": "val"},
+    }
+    assert subscription.connection_pong_request() == {"type": "pong"}
+    assert subscription.connection_pong_request(payload={"key": "val"}) == {
+        "type": "pong",
+        "payload": {"key": "val"},
+    }
+
+
+def test_subscription_protocols_generator_not_exhausted() -> None:
+    def gen_protocols() -> Any:
+        yield "graphql-ws"
+
+    subscription = GraphQLSubscription(
+        request=GraphQLRequest(query="{ city { name } }"),
+        protocols=gen_protocols(),
+    )
+    # Check that protocols was converted to tuple
+    assert isinstance(subscription.protocols, tuple)
+    assert subscription.protocols == ("graphql-ws",)
+
+    # Calling start and stop repeatedly should be consistent
+    start1 = subscription.connection_start_request()
+    start2 = subscription.connection_start_request()
+    stop1 = subscription.connection_stop_request()
+    stop2 = subscription.connection_stop_request()
+
+    assert start1["type"] == GraphQLSubscriptionEventType.START.value
+    assert start2["type"] == GraphQLSubscriptionEventType.START.value
+    assert stop1["type"] == GraphQLSubscriptionEventType.STOP.value
+    assert stop2["type"] == GraphQLSubscriptionEventType.STOP.value
+
+
+def test_subscription_unnegotiated_fallback_with_default_protocols() -> None:
+    # Default protocols contains graphql-ws, so unnegotiated (None) should fall back to legacy graphql-ws
+    subscription = GraphQLSubscription(
+        request=GraphQLRequest(query="{ city { name } }")
+    )
+    start_req = subscription.connection_start_request(protocol=None)
+    stop_req = subscription.connection_stop_request(protocol=None)
+    assert start_req["type"] == GraphQLSubscriptionEventType.START.value
+    assert stop_req["type"] == GraphQLSubscriptionEventType.STOP.value
+
+
+def test_subscription_unnegotiated_fallback_with_modern_only_protocols() -> None:
+    subscription = GraphQLSubscription(
+        request=GraphQLRequest(query="{ city { name } }"),
+        protocols=["graphql-transport-ws"],
+    )
+    start_req = subscription.connection_start_request(protocol=None)
+    stop_req = subscription.connection_stop_request(protocol=None)
+    assert start_req["type"] == GraphQLSubscriptionEventType.SUBSCRIBE.value
+    assert stop_req["type"] == GraphQLSubscriptionEventType.COMPLETE.value

--- a/tests/test_subscription_failures.py
+++ b/tests/test_subscription_failures.py
@@ -24,10 +24,15 @@ if TYPE_CHECKING:
 
 
 class MockWebSocketResponse(GraphQLWebSocketResponse):
-    def __init__(self, messages: list[str]) -> None:
+    def __init__(self, messages: list[str], subprotocol: str | None = None) -> None:
         self.messages = messages
         self.sent: list[str] = []
         self.closed = False
+        self._subprotocol = subprotocol
+
+    @property
+    def subprotocol(self) -> str | None:
+        return self._subprotocol
 
     async def __aenter__(self) -> MockWebSocketResponse:
         return self
@@ -82,20 +87,76 @@ async def test_subscription_handle_server_error(ws_message_error: str) -> None:
     assert cast("GraphQLResponse", event.payload).json["message"] == "an error occurred"
 
 
+async def test_subscription_handle_graphql_transport_ws_error_list() -> None:
+    import json
+
+    req = GraphQLRequest(query="subscription { city { name } }")
+    sub = GraphQLSubscription(request=req)
+    sub_id = "test-subscription-id"
+    object.__setattr__(sub, "id", sub_id)
+
+    # In graphql-transport-ws, payload is a list of GraphQL errors
+    error_msg = json.dumps(
+        {
+            "id": sub_id,
+            "type": "error",
+            "payload": [{"message": "Syntax Error", "locations": [{"line": 1}]}],
+        }
+    )
+
+    mock_transport = MagicMock(spec=GraphQLSubscriptionTransport)
+    mock_ws = MockWebSocketResponse([error_msg], subprotocol="graphql-transport-ws")
+    mock_transport.subscribe.return_value = mock_ws
+
+    mock_on_error = MagicMock()
+    registry = cast("CallbackRegistry", sub.callbacks)
+    registry.register(GraphQLSubscriptionEventType.ERROR, mock_on_error)
+
+    await sub._websocket_connect("ws://test", mock_transport)
+
+    mock_on_error.assert_called_once()
+    from aiographql.client.subscription import GraphQLSubscriptionEvent
+
+    event = cast("GraphQLSubscriptionEvent", mock_on_error.call_args[0][0])
+    assert event.type == GraphQLSubscriptionEventType.ERROR
+    resp = cast("GraphQLResponse", event.payload)
+    assert resp.errors[0].message == "Syntax Error"
+
+
+async def test_subscription_handle_server_ping_pong() -> None:
+    import json
+
+    req = GraphQLRequest(query="subscription { city { name } }")
+    sub = GraphQLSubscription(request=req)
+    sub_id = "test-subscription-id"
+    object.__setattr__(sub, "id", sub_id)
+
+    ping_msg = json.dumps({"type": "ping", "payload": {"serverTime": 12345}})
+    complete_msg = json.dumps({"id": sub_id, "type": "complete"})
+
+    mock_transport = MagicMock(spec=GraphQLSubscriptionTransport)
+    mock_ws = MockWebSocketResponse(
+        [ping_msg, complete_msg], subprotocol="graphql-transport-ws"
+    )
+    mock_transport.subscribe.return_value = mock_ws
+
+    await sub._websocket_connect("ws://test", mock_transport)
+
+    # Verify that client sent connection_init, and on receiving ping sent pong with matching payload
+    assert len(mock_ws.sent) >= 2
+    sent_msgs = [json.loads(s) for s in mock_ws.sent]
+    pong_msgs = [m for m in sent_msgs if m.get("type") == "pong"]
+    assert len(pong_msgs) == 1
+    assert pong_msgs[0] == {"type": "pong", "payload": {"serverTime": 12345}}
+
+
 async def test_subscription_handle_invalid_json(ws_message_invalid_json: str) -> None:
     req = GraphQLRequest(query="subscription { city { name } }")
     sub = GraphQLSubscription(request=req)
 
     mock_transport = MagicMock(spec=GraphQLSubscriptionTransport)
-    # The subscription loop should probably not crash on invalid JSON,
-    # but currently it might if loads() raises.
-    # Let's see what happens.
     mock_ws = MockWebSocketResponse([ws_message_invalid_json])
     mock_transport.subscribe.return_value = mock_ws
-
-    # If it raises, we might want to catch it or ensure it's handled.
-    # Based on _websocket_connect code, it calls serializer.loads(data) directly.
-    # DefaultSerializer.loads uses orjson.loads which raises orjson.JSONDecodeError
 
     with pytest.raises(
         Exception, match="unexpected end of data"
@@ -117,3 +178,44 @@ async def test_subscription_complete_breaks_loop(ws_message_complete: str) -> No
     # If it broke correctly, it should only have consumed the complete message
     assert len(mock_ws.messages) == 1
     assert mock_ws.messages[0] == '{"type":"data"}'
+
+
+async def test_subscription_custom_transport_no_subprotocol_attr() -> None:
+    class MinimalCustomWSResponse:
+        def __init__(self) -> None:
+            self.messages = ['{"type":"complete"}']
+            self.sent: list[str] = []
+
+        async def __aenter__(self) -> MinimalCustomWSResponse:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            pass
+
+        async def send_str(self, data: str) -> None:
+            self.sent.append(data)
+
+        def __aiter__(self) -> MinimalCustomWSResponse:
+            return self
+
+        async def __anext__(self) -> str:
+            if not self.messages:
+                raise StopAsyncIteration
+            return self.messages.pop(0)
+
+    req = GraphQLRequest(query="subscription { city { name } }")
+    sub = GraphQLSubscription(request=req)
+
+    mock_transport = MagicMock(spec=GraphQLSubscriptionTransport)
+    mock_transport.close = MagicMock()
+
+    async def async_close() -> None:
+        pass
+
+    mock_transport.close = async_close
+    mock_ws = MinimalCustomWSResponse()
+    mock_transport.subscribe.return_value = mock_ws
+
+    # Should not raise AttributeError: 'MinimalCustomWSResponse' object has no attribute 'subprotocol'
+    await sub._websocket_connect("ws://test", mock_transport)
+    assert len(mock_ws.sent) >= 1


### PR DESCRIPTION
I have implemented first-class support for the modern GraphQL Foundation `graphql-transport-ws` protocol as the default for subscriptions, alongside full backward compatibility for the legacy `subscriptions-transport-ws` (`graphql-ws`) protocol.

**Key Changes**
* **Protocol support and negotiation**: Defaulted subscription protocols to `("graphql-transport-ws", "graphql-ws")`. The client inspects the negotiated subprotocol returned during handshake and frames requests accordingly (`subscribe` vs `start`, `complete` vs `stop`).
* **Bidirectional ping/pong**: Added automated response to server `ping` events with a matching `pong` payload in `graphql-transport-ws`.
* **Payload and event handling**: Extended `GraphQLSubscriptionEvent.payload` to handle list-based error payloads and `NEXT` data events.
* **Backward compatibility**: Added cross-dispatching for `NEXT` <-> `DATA` and `PING` <-> `KEEP_ALIVE` callbacks so existing handler registries continue to work without modification.
* **Testing and documentation**: Added comprehensive unit tests and verified integration tests against Strawberry (both protocols), Apollo v2, and Hasura.