### PR TITLE
feat(client): implement GraphQL-over-HTTP compliance

### DIFF
--- a/src/aiographql/client/client.py
+++ b/src/aiographql/client/client.py
@@ -70,9 +70,10 @@ class GraphQLClient:
 
     :param endpoint: URI of graph api.
     :param headers: Default headers to use for every request made by this client.
-        By default the client adds 'Content-Type: application/json' and
+        By default the client adds 'Content-Type: application/json',
+        'Accept: application/graphql-response+json, application/json' and
         'Accept-Encoding: gzip' to all requests. These can be overridden by
-        specifying then here.
+        specifying them here.
     :param method: Default method to use when submitting a GraphQL request to the
         specified `endpoint`.
     :param session: Optional :class:`GraphQLSession` to use when making requests.
@@ -107,7 +108,11 @@ class GraphQLClient:
     ) -> None:
         self.endpoint = endpoint
         self._method = method or GraphQLQueryMethod.post
-        self._headers = {"Content-Type": "application/json", "Accept-Encoding": "gzip"}
+        self._headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/graphql-response+json, application/json",
+            "Accept-Encoding": "gzip",
+        }
         self._headers.update(headers or {})
         self._schema = schema
         self._validate = validate
@@ -244,6 +249,7 @@ class GraphQLClient:
         request: GraphQLRequest | str,
         operation: str | None = None,
         variables: dict[str, Any] | None = None,
+        extensions: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
     ) -> GraphQLRequest:
         """
@@ -257,9 +263,10 @@ class GraphQLClient:
         :param variables: Query variables to set for the provided request. This will
                           override the default values for any existing variables in the
                           request if set.
+        :param extensions: Query extensions to set for the provided request.
         :param headers: Additional headers to be set when sending HTTP request.
         :return: A copy of the `request` object with the specified values of
-            `operation`, `variables` and `headers` set/merged.
+            `operation`, `variables`, `extensions` and `headers` set/merged.
         """
         if isinstance(request, str):
             request = GraphQLRequest(query=request, codec=self._codec)
@@ -269,6 +276,7 @@ class GraphQLClient:
             headers_fallback=self._headers,
             operation=operation,
             variables=variables,
+            extensions=extensions,
             codec=self._codec,
         )
 
@@ -288,6 +296,7 @@ class GraphQLClient:
         headers: dict[str, str] | None = None,
         operation: str | None = None,
         variables: dict[str, Any] | None = None,
+        extensions: dict[str, Any] | None = None,
         session: GraphQLSession | None = None,
     ) -> T:
         """
@@ -301,6 +310,7 @@ class GraphQLClient:
         :param headers: Additional headers to be set when sending HTTP request.
         :param operation: GraphQL operation name to use.
         :param variables: Query variables to set for the provided request.
+        :param extensions: Query extensions to set for the provided request.
         :param session: Optional `GraphQLSession` to use for requests.
         :return: The decoded data.
         """
@@ -310,6 +320,7 @@ class GraphQLClient:
             headers=headers,
             operation=operation,
             variables=variables,
+            extensions=extensions,
             session=session,
         )
         return response.data_as(result_type, path=path, codec=self._codec)
@@ -321,6 +332,7 @@ class GraphQLClient:
         headers: dict[str, str] | None = None,
         operation: str | None = None,
         variables: dict[str, Any] | None = None,
+        extensions: dict[str, Any] | None = None,
         session: GraphQLSession | None = None,
     ) -> GraphQLResponse:
         """
@@ -347,11 +359,16 @@ class GraphQLClient:
         :param variables: Query variables to set for the provided request. This will
                           override the default values for any existing variables in the
                           request if set.
+        :param extensions: Query extensions to set for the provided request.
         :param session: Optional `GraphQLSession` to use for requests
         :return: The resulting response object.
         """
         request = self._prepare_request(
-            request=request, operation=operation, variables=variables, headers=headers
+            request=request,
+            operation=operation,
+            variables=variables,
+            extensions=extensions,
+            headers=headers,
         )
 
         await self.validate(request=request)
@@ -370,6 +387,7 @@ class GraphQLClient:
         headers: dict[str, str] | None = None,
         operation: str | None = None,
         variables: dict[str, Any] | None = None,
+        extensions: dict[str, Any] | None = None,
         session: GraphQLSession | None = None,
     ) -> GraphQLResponse:
         """
@@ -384,6 +402,7 @@ class GraphQLClient:
         :param variables: Query variables to set for the provided request. This will
                           override the default values for any existing variables in the
                           request if set.
+        :param extensions: Query extensions to set for the provided request.
         :param session: Optional `GraphQLSession` to use for requests
         :return: The resulting `GraphQLResponse` object.
         """
@@ -393,6 +412,7 @@ class GraphQLClient:
             headers=headers,
             operation=operation,
             variables=variables,
+            extensions=extensions,
             session=session,
         )
 
@@ -402,6 +422,7 @@ class GraphQLClient:
         headers: dict[str, str] | None = None,
         operation: str | None = None,
         variables: dict[str, Any] | None = None,
+        extensions: dict[str, Any] | None = None,
         session: GraphQLSession | None = None,
     ) -> GraphQLResponse:
         """
@@ -416,6 +437,7 @@ class GraphQLClient:
         :param variables: Query variables to set for the provided request. This will
                           override the default values for any existing variables in the
                           request if set.
+        :param extensions: Query extensions to set for the provided request.
         :param session: Optional `GraphQLSession` to use for requests
         :return: The resulting `GraphQLResponse` object.
         """
@@ -425,6 +447,7 @@ class GraphQLClient:
             headers=headers,
             operation=operation,
             variables=variables,
+            extensions=extensions,
             session=session,
         )
 
@@ -434,6 +457,7 @@ class GraphQLClient:
         headers: dict[str, str] | None = None,
         operation: str | None = None,
         variables: dict[str, Any] | None = None,
+        extensions: dict[str, Any] | None = None,
         callbacks: CallbacksType | None = None,
         on_data: CallbackType | None = None,
         on_error: CallbackType | None = None,
@@ -472,6 +496,7 @@ class GraphQLClient:
         :param variables: Query variables to set for the provided request. This will
                           override the default values for any existing variables in the
                           request if set.
+        :param extensions: Query extensions to set for the provided request.
         :param session: Optional `GraphQLSession` to use for requests
         :return: The resulting `GraphQLResponse` object.
         :param callbacks: Custom callback registry mapping an event to one more more
@@ -491,7 +516,11 @@ class GraphQLClient:
         :return: The initialised subscription.
         """
         request = self._prepare_request(
-            request=request, operation=operation, variables=variables, headers=headers
+            request=request,
+            operation=operation,
+            variables=variables,
+            extensions=extensions,
+            headers=headers,
         )
         await self.validate(request=request)
 

--- a/src/aiographql/client/request.py
+++ b/src/aiographql/client/request.py
@@ -25,6 +25,7 @@ class GraphQLRequest:
         schema from the server.
     :param headers: Headers to use, in addition to client default headers when making
         the HTTP request.
+    :param extensions: Optional dictionary of extensions to pass with the query.
     """
 
     query: str
@@ -34,6 +35,7 @@ class GraphQLRequest:
     validate: bool = True
     headers: dict[str, str] = dataclasses.field(default_factory=dict)
     codec: GraphQLCodec | None = dataclasses.field(default=None, compare=False)
+    extensions: dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self, operation: str | None) -> None:
         if operation is not None:
@@ -48,7 +50,7 @@ class GraphQLRequest:
         from aiographql.client.codec import DefaultGraphQLCodec
 
         codec = self.codec or DefaultGraphQLCodec()
-        payload = {
+        payload: dict[str, Any] = {
             "query": self.query,
             "variables": cast("DefaultGraphQLCodec", codec).encode(
                 self.variables, include_primitives=False
@@ -58,6 +60,8 @@ class GraphQLRequest:
         }
         if self.operationName is not None:
             payload["operationName"] = self.operationName
+        if self.extensions:
+            payload["extensions"] = self.extensions
         return payload
 
     def asdict(self) -> dict[str, Any]:
@@ -65,6 +69,7 @@ class GraphQLRequest:
             "query": self.query,
             "operationName": self.operationName,
             "variables": self.variables,
+            "extensions": self.extensions,
         }
 
     def copy(
@@ -73,12 +78,14 @@ class GraphQLRequest:
         headers_fallback: dict[str, str] | None = None,
         operation: str | None = None,
         variables: dict[str, Any] | None = None,
+        extensions: dict[str, Any] | None = None,
         codec: GraphQLCodec | None = None,
     ) -> GraphQLRequest:
         return dataclasses.replace(
             self,
             operation=operation or self.operationName,
             variables={**deepcopy(self.variables), **(variables or {})},
+            extensions={**deepcopy(self.extensions), **(extensions or {})},
             headers={
                 **(headers_fallback or {}),
                 **self.headers,
@@ -94,6 +101,7 @@ class GraphQLRequestContainer:
     headers: dataclasses.InitVar[dict[str, str] | None] = None
     operation: dataclasses.InitVar[str | None] = None
     variables: dataclasses.InitVar[dict[str, Any] | None] = None
+    extensions: dataclasses.InitVar[dict[str, Any] | None] = None
     codec: dataclasses.InitVar[GraphQLCodec | None] = None
 
     def __post_init__(
@@ -101,18 +109,27 @@ class GraphQLRequestContainer:
         headers: dict[str, str] | None,
         operation: str | None,
         variables: dict[str, Any] | None,
+        extensions: dict[str, Any] | None,
         codec: GraphQLCodec | None,
     ) -> None:
         object.__setattr__(
             self,
             "request",
             (
-                GraphQLRequest(query=self.request, codec=codec)
+                GraphQLRequest(
+                    query=self.request,
+                    headers=headers or {},
+                    operation=operation,
+                    variables=variables or {},
+                    extensions=extensions or {},
+                    codec=codec,
+                )
                 if isinstance(self.request, str)
                 else self.request.copy(
                     headers=headers,
                     operation=operation,
                     variables=variables,
+                    extensions=extensions,
                     codec=codec,
                 )
             ),

--- a/src/aiographql/client/response.py
+++ b/src/aiographql/client/response.py
@@ -26,12 +26,14 @@ class GraphQLBaseResponse(GraphQLRequestContainer):
         headers: dict[str, str] | None,
         operation: str | None,
         variables: dict[str, Any] | None,
+        extensions: dict[str, Any] | None,
         codec: GraphQLCodec | None,
     ) -> None:
         super().__post_init__(
             headers=headers,
             operation=operation,
             variables=variables,
+            extensions=extensions,
             codec=codec,
         )
 

--- a/src/aiographql/client/subscription.py
+++ b/src/aiographql/client/subscription.py
@@ -146,12 +146,14 @@ class GraphQLSubscription(GraphQLRequestContainer):
         headers: dict[str, str] | None,
         operation: str | None,
         variables: dict[str, Any] | None,
+        extensions: dict[str, Any] | None,
         codec: GraphQLCodec | None,
     ) -> None:
         super().__post_init__(
             headers=headers,
             operation=operation,
             variables=variables,
+            extensions=extensions,
             codec=codec,
         )
 

--- a/src/aiographql/client/transport/aiohttp.py
+++ b/src/aiographql/client/transport/aiohttp.py
@@ -12,6 +12,8 @@ from aiographql.client.response import GraphQLResponse
 from aiographql.client.transport.base import GraphQLSubscriptionTransport
 from aiographql.client.transport.base import GraphQLTransport
 from aiographql.client.transport.base import GraphQLWebSocketResponse
+from aiographql.client.transport.base import is_graphql_response
+from aiographql.client.transport.base import prepare_get_params
 
 
 if TYPE_CHECKING:
@@ -86,13 +88,7 @@ class AiohttpTransport(GraphQLTransport):
         if method == "post":
             kwargs.setdefault("data", serializer.dumps(request.payload()))
         elif method == "get":
-            params = {
-                k: str(v)
-                if not isinstance(v, (dict, list, bool))
-                else self._coerce_value(v, serializer)
-                for k, v in request.payload().items()
-            }
-            kwargs.setdefault("params", params)
+            kwargs.setdefault("params", prepare_get_params(request, serializer))
         else:
             raise GraphQLClientException(f"Invalid method ({method}) specified")
 
@@ -125,27 +121,21 @@ class AiohttpTransport(GraphQLTransport):
                 except Exception:
                     body = None
 
-                response = GraphQLResponse(request=request, json=body)
+                response = GraphQLResponse(
+                    request=request, json=body if isinstance(body, dict) else {}
+                )
 
-                if 200 <= resp.status < 300:
+                content_type = (
+                    getattr(resp, "headers", {}).get("Content-Type")
+                    if hasattr(resp, "headers")
+                    else None
+                )
+                if is_graphql_response(resp.status, content_type, body):
                     return response
 
                 raise GraphQLRequestException(response)
         except aiohttp.ClientError as exc:
             raise GraphQLTransportException(f"HTTP request failed: {exc}") from exc
-
-    @staticmethod
-    def _coerce_value(value: Any, serializer: GraphQLSerializer) -> Any:
-        if isinstance(value, bool):
-            return int(value)
-        if isinstance(value, (dict, list)):
-            serialized = serializer.dumps(value)
-            return (
-                serialized.decode("utf-8")
-                if isinstance(serialized, bytes)
-                else serialized
-            )
-        return value
 
     async def close(self) -> None:
         if self._session is not None and self._owns_session:

--- a/src/aiographql/client/transport/base.py
+++ b/src/aiographql/client/transport/base.py
@@ -19,6 +19,72 @@ if TYPE_CHECKING:
 
 GraphQLSession: TypeAlias = Union["aiohttp.ClientSession", "httpx.AsyncClient"]
 
+GRAPHQL_RESPONSE_MEDIA_TYPE: str = "application/graphql-response+json"
+
+
+def prepare_get_params(
+    request: GraphQLRequest, serializer: GraphQLSerializer
+) -> dict[str, str]:
+    """
+    Prepare GET query parameters conforming to the GraphQL-over-HTTP specification.
+    """
+    params: dict[str, str] = {"query": request.query}
+    if request.operationName is not None:
+        params["operationName"] = request.operationName
+    if request.variables:
+        encoded_vars = request.payload().get("variables")
+        if encoded_vars:
+            serialized = serializer.dumps(encoded_vars)
+            params["variables"] = (
+                serialized.decode("utf-8")
+                if isinstance(serialized, bytes)
+                else str(serialized)
+            )
+    if request.extensions:
+        serialized = serializer.dumps(request.extensions)
+        params["extensions"] = (
+            serialized.decode("utf-8")
+            if isinstance(serialized, bytes)
+            else str(serialized)
+        )
+    return params
+
+
+def _is_valid_graphql_payload(body: Any) -> bool:
+    if not isinstance(body, dict):
+        return False
+    has_data = "data" in body
+    has_errors = "errors" in body
+    if not (has_data or has_errors):
+        return False
+    if has_errors:
+        errors = body["errors"]
+        if not isinstance(errors, list) or not all(
+            isinstance(err, dict) for err in errors
+        ):
+            return False
+    if has_data:
+        data = body["data"]
+        if data is not None and not isinstance(data, dict):
+            return False
+    return True
+
+
+def is_graphql_response(status_code: int, content_type: str | None, body: Any) -> bool:
+    """
+    Determine if an HTTP response represents a valid GraphQL execution response
+    under the GraphQL-over-HTTP specification.
+    """
+    if 200 <= status_code < 300:
+        return True
+    if content_type:
+        media_type = content_type.split(";")[0].strip().lower()
+        if media_type == GRAPHQL_RESPONSE_MEDIA_TYPE and _is_valid_graphql_payload(
+            body
+        ):
+            return True
+    return False
+
 
 @runtime_checkable
 class GraphQLTransport(Protocol):

--- a/src/aiographql/client/transport/httpx.py
+++ b/src/aiographql/client/transport/httpx.py
@@ -10,6 +10,8 @@ from aiographql.client.exceptions import GraphQLRequestException
 from aiographql.client.exceptions import GraphQLTransportException
 from aiographql.client.response import GraphQLResponse
 from aiographql.client.transport.base import GraphQLTransport
+from aiographql.client.transport.base import is_graphql_response
+from aiographql.client.transport.base import prepare_get_params
 
 
 if TYPE_CHECKING:
@@ -75,13 +77,7 @@ class HttpxTransport(GraphQLTransport):
         if method == "POST":
             kwargs.setdefault("content", serializer.dumps(request.payload()))
         elif method == "GET":
-            params = {
-                k: str(v)
-                if not isinstance(v, (dict, list, bool))
-                else self._coerce_value(v, serializer)
-                for k, v in request.payload().items()
-            }
-            kwargs.setdefault("params", params)
+            kwargs.setdefault("params", prepare_get_params(request, serializer))
         else:
             raise GraphQLClientException(f"Invalid method ({method}) specified")
 
@@ -129,11 +125,9 @@ class HttpxTransport(GraphQLTransport):
                 request=request, json=body if isinstance(body, dict) else {}
             )
 
-            if (
-                200
-                <= int(getattr(resp, "status_code", getattr(resp, "status", 0)))
-                < 300
-            ):
+            status_code = int(getattr(resp, "status_code", getattr(resp, "status", 0)))
+            content_type = getattr(resp, "headers", {}).get("content-type")
+            if is_graphql_response(status_code, content_type, body):
                 return response
 
             raise GraphQLRequestException(response)
@@ -149,18 +143,6 @@ class HttpxTransport(GraphQLTransport):
                     pass
                 raise GraphQLTransportException(f"HTTP request failed: {exc}") from exc
             raise
-
-    def _coerce_value(self, value: Any, serializer: GraphQLSerializer) -> Any:
-        if isinstance(value, bool):
-            return int(value)
-        if isinstance(value, (dict, list)):
-            serialized = serializer.dumps(value)
-            return (
-                serialized.decode("utf-8")
-                if isinstance(serialized, bytes)
-                else serialized
-            )
-        return value
 
     async def close(self) -> None:
         if self._client is not None and self._owns_client:

--- a/tests/test_aiohttp_transport.py
+++ b/tests/test_aiohttp_transport.py
@@ -14,7 +14,6 @@ from aiographql.client.exceptions import GraphQLClientException
 from aiographql.client.exceptions import GraphQLTransportException
 from aiographql.client.request import GraphQLRequest
 from aiographql.client.serializer import DefaultSerializer
-from aiographql.client.serializer import JSONSerializer
 from aiographql.client.transport.aiohttp import AiohttpTransport
 from aiographql.client.transport.aiohttp import AiohttpWebSocketResponse
 
@@ -116,18 +115,7 @@ async def test_aiohttp_transport_invalid_json_response(
     )
 
     resp = await transport.request("POST", request, serializer)
-    assert resp.json is None
-
-
-async def test_aiohttp_transport_coerce_value_async() -> None:
-    transport = AiohttpTransport(endpoint="http://test.com")
-    serializer = DefaultSerializer()
-
-    assert transport._coerce_value(True, serializer) == 1
-    assert transport._coerce_value(False, serializer) == 0
-    assert transport._coerce_value({"a": 1}, serializer) == '{"a":1}'
-    assert transport._coerce_value([1, 2], serializer) == "[1,2]"
-    assert transport._coerce_value("string", serializer) == "string"
+    assert resp.json == {}
 
 
 async def test_aiohttp_transport_invalid_method_async() -> None:
@@ -136,24 +124,6 @@ async def test_aiohttp_transport_invalid_method_async() -> None:
         await transport.request(
             "INVALID", GraphQLRequest(query="{test}"), DefaultSerializer()
         )
-
-
-async def test_aiohttp_transport_coerce_value_extra() -> None:
-    transport = AiohttpTransport(endpoint="http://localhost")
-    serializer = JSONSerializer()
-
-    # Test boolean coercion
-    assert transport._coerce_value(True, serializer) == 1
-    assert transport._coerce_value(False, serializer) == 0
-
-    # Test dict/list coercion
-    data_dict = {"a": 1}
-    coerced_dict = transport._coerce_value(data_dict, serializer)
-    assert coerced_dict == '{"a": 1}'
-
-    data_list = [1, 2]
-    coerced_list = transport._coerce_value(data_list, serializer)
-    assert coerced_list == "[1, 2]"
 
 
 async def test_aiohttp_websocket_response_anext() -> None:

--- a/tests/test_graphql_over_http.py
+++ b/tests/test_graphql_over_http.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mocket.plugins.httpretty import HTTPretty
+
+from aiographql.client import GraphQLClient
+from aiographql.client import GraphQLRequest
+from aiographql.client import GraphQLResponse
+from aiographql.client.exceptions import GraphQLRequestException
+from aiographql.client.serializer import DefaultSerializer
+from aiographql.client.transport.aiohttp import AiohttpTransport
+from aiographql.client.transport.base import GRAPHQL_RESPONSE_MEDIA_TYPE
+from aiographql.client.transport.base import is_graphql_response
+from aiographql.client.transport.base import prepare_get_params
+from aiographql.client.transport.httpx import HttpxTransport
+
+
+def test_prepare_get_params_query_only() -> None:
+    serializer = DefaultSerializer()
+    req = GraphQLRequest(query="{ hello }")
+    params = prepare_get_params(req, serializer)
+    assert params == {"query": "{ hello }"}
+
+
+def test_prepare_get_params_all_fields() -> None:
+    serializer = DefaultSerializer()
+    req = GraphQLRequest(
+        query="query GetUser($active: Boolean!, $limit: Int!) { user(active: $active, limit: $limit) { id } }",
+        operation="GetUser",
+        variables={"active": True, "limit": 10},
+        extensions={"persistedQuery": {"version": 1, "sha256Hash": "abc"}},
+    )
+    params = prepare_get_params(req, serializer)
+    assert params["query"] == req.query
+    assert params["operationName"] == "GetUser"
+    assert serializer.loads(params["variables"]) == {"active": True, "limit": 10}
+    assert serializer.loads(params["extensions"]) == {
+        "persistedQuery": {"version": 1, "sha256Hash": "abc"}
+    }
+
+
+def test_prepare_get_params_omits_empty() -> None:
+    serializer = DefaultSerializer()
+    req = GraphQLRequest(
+        query="{ test }",
+        variables={},
+        extensions={},
+    )
+    params = prepare_get_params(req, serializer)
+    assert params == {"query": "{ test }"}
+    assert "variables" not in params
+    assert "extensions" not in params
+    assert "operationName" not in params
+
+
+def test_is_graphql_response() -> None:
+    # 2xx is always accepted
+    assert is_graphql_response(200, "application/json", {"data": {"hello": "world"}})
+    assert is_graphql_response(
+        200, "application/graphql-response+json", {"data": {"hello": "world"}}
+    )
+
+    # 4xx / 5xx with application/graphql-response+json
+    assert is_graphql_response(
+        400,
+        GRAPHQL_RESPONSE_MEDIA_TYPE,
+        {"errors": [{"message": "Syntax error"}]},
+    )
+    assert is_graphql_response(
+        422,
+        f"{GRAPHQL_RESPONSE_MEDIA_TYPE}; charset=utf-8",
+        {"errors": [{"message": "Unprocessable"}]},
+    )
+    assert is_graphql_response(
+        400,
+        GRAPHQL_RESPONSE_MEDIA_TYPE,
+        {"data": None, "errors": [{"message": "Error"}]},
+    )
+
+    # 4xx with application/json or HTML should NOT be treated as a GraphQL execution response
+    assert not is_graphql_response(
+        400, "application/json", {"errors": [{"message": "Bad request"}]}
+    )
+    assert not is_graphql_response(404, "text/html", "Not Found")
+    assert not is_graphql_response(500, "text/html", "Internal Server Error")
+    assert not is_graphql_response(400, GRAPHQL_RESPONSE_MEDIA_TYPE, None)
+    assert not is_graphql_response(400, GRAPHQL_RESPONSE_MEDIA_TYPE, "invalid body")
+    assert not is_graphql_response(
+        500, GRAPHQL_RESPONSE_MEDIA_TYPE, {"errors": "Internal failure"}
+    )
+    assert not is_graphql_response(
+        400, GRAPHQL_RESPONSE_MEDIA_TYPE, {"errors": ["not a dict"]}
+    )
+    assert not is_graphql_response(
+        400, GRAPHQL_RESPONSE_MEDIA_TYPE, {"data": "not a dict or null"}
+    )
+    assert not is_graphql_response(
+        400, GRAPHQL_RESPONSE_MEDIA_TYPE, {"unexpected": "structure"}
+    )
+
+
+@pytest.mark.aiohttp
+@pytest.mark.asyncio
+async def test_aiohttp_transport_400_graphql_response(
+    mocket: Any, httpretty: Any
+) -> None:
+    endpoint = "http://test.com/graphql"
+    transport = AiohttpTransport(endpoint=endpoint)
+    request = GraphQLRequest(query="{ invalid }")
+    serializer = DefaultSerializer()
+
+    httpretty.register_uri(
+        HTTPretty.POST,
+        endpoint,
+        body='{"errors": [{"message": "Cannot query field invalid"}]}',
+        status=400,
+        content_type=GRAPHQL_RESPONSE_MEDIA_TYPE,
+    )
+
+    response = await transport.request("POST", request, serializer)
+    assert isinstance(response, GraphQLResponse)
+    assert len(response.errors) == 1
+    assert response.errors[0].message == "Cannot query field invalid"
+
+
+@pytest.mark.httpx
+@pytest.mark.asyncio
+async def test_httpx_transport_400_graphql_response(
+    mocket: Any, httpretty: Any
+) -> None:
+    endpoint = "http://test.com/graphql"
+    transport = HttpxTransport(endpoint=endpoint)
+    request = GraphQLRequest(query="{ invalid }")
+    serializer = DefaultSerializer()
+
+    httpretty.register_uri(
+        HTTPretty.POST,
+        endpoint,
+        body='{"errors": [{"message": "Cannot query field invalid"}]}',
+        status=400,
+        content_type=GRAPHQL_RESPONSE_MEDIA_TYPE,
+    )
+
+    response = await transport.request("POST", request, serializer)
+    assert isinstance(response, GraphQLResponse)
+    assert len(response.errors) == 1
+    assert response.errors[0].message == "Cannot query field invalid"
+
+
+@pytest.mark.aiohttp
+@pytest.mark.asyncio
+async def test_aiohttp_transport_400_legacy_json_raises(
+    mocket: Any, httpretty: Any
+) -> None:
+    endpoint = "http://test.com/graphql"
+    transport = AiohttpTransport(endpoint=endpoint)
+    request = GraphQLRequest(query="{ invalid }")
+    serializer = DefaultSerializer()
+
+    httpretty.register_uri(
+        HTTPretty.POST,
+        endpoint,
+        body='{"errors": [{"message": "Bad Request"}]}',
+        status=400,
+        content_type="application/json",
+    )
+
+    with pytest.raises(GraphQLRequestException) as excinfo:
+        await transport.request("POST", request, serializer)
+    assert excinfo.value.response.json == {"errors": [{"message": "Bad Request"}]}
+
+
+@pytest.mark.asyncio
+async def test_client_query_with_extensions(mocket: Any, httpretty: Any) -> None:
+    endpoint = "http://test.com/graphql"
+    httpretty.register_uri(
+        HTTPretty.POST,
+        endpoint,
+        body='{"data": {"hello": "world"}}',
+        status=200,
+        content_type=GRAPHQL_RESPONSE_MEDIA_TYPE,
+    )
+
+    client = GraphQLClient(endpoint=endpoint, validate=False)
+    response = await client.query(
+        request="{ hello }",
+        extensions={"persistedQuery": {"version": 1}},
+    )
+    assert response.data == {"hello": "world"}
+    assert isinstance(response.request, GraphQLRequest)
+    assert response.request.extensions == {"persistedQuery": {"version": 1}}
+
+
+@pytest.mark.asyncio
+async def test_client_get_with_extensions(mocket: Any, httpretty: Any) -> None:
+    endpoint = "http://test.com/graphql"
+    httpretty.register_uri(
+        HTTPretty.GET,
+        endpoint,
+        body='{"data": {"hello": "world"}}',
+        status=200,
+        content_type=GRAPHQL_RESPONSE_MEDIA_TYPE,
+    )
+
+    client = GraphQLClient(endpoint=endpoint, validate=False)
+    response = await client.get(
+        request=GraphQLRequest(query="{ hello }"),
+        extensions={"persistedQuery": {"version": 1}},
+    )
+    assert response.data == {"hello": "world"}
+    assert isinstance(response.request, GraphQLRequest)
+    assert response.request.extensions == {"persistedQuery": {"version": 1}}
+
+
+@pytest.mark.asyncio
+async def test_client_post_with_extensions(mocket: Any, httpretty: Any) -> None:
+    endpoint = "http://test.com/graphql"
+    httpretty.register_uri(
+        HTTPretty.POST,
+        endpoint,
+        body='{"data": {"hello": "world"}}',
+        status=200,
+        content_type=GRAPHQL_RESPONSE_MEDIA_TYPE,
+    )
+
+    client = GraphQLClient(endpoint=endpoint, validate=False)
+    response = await client.post(
+        request=GraphQLRequest(query="{ hello }"),
+        extensions={"persistedQuery": {"version": 1}},
+    )
+    assert response.data == {"hello": "world"}
+    assert isinstance(response.request, GraphQLRequest)
+    assert response.request.extensions == {"persistedQuery": {"version": 1}}
+
+
+@pytest.mark.httpx
+@pytest.mark.asyncio
+async def test_httpx_transport_400_legacy_json_raises(
+    mocket: Any, httpretty: Any
+) -> None:
+    endpoint = "http://test.com/graphql"
+    transport = HttpxTransport(endpoint=endpoint)
+    request = GraphQLRequest(query="{ invalid }")
+    serializer = DefaultSerializer()
+
+    httpretty.register_uri(
+        HTTPretty.POST,
+        endpoint,
+        body='{"errors": [{"message": "Bad Request"}]}',
+        status=400,
+        content_type="application/json",
+    )
+
+    with pytest.raises(GraphQLRequestException) as excinfo:
+        await transport.request("POST", request, serializer)
+    assert excinfo.value.response.json == {"errors": [{"message": "Bad Request"}]}

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -70,3 +70,13 @@ async def test_no_headers(server: str, client: GraphQLClient, query_city: str) -
     request = GraphQLRequest(query=query_city)
     with pytest.raises(GraphQLIntrospectionException):
         await client.post(request)
+
+
+async def test_default_client_headers() -> None:
+    client = GraphQLClient(endpoint="http://example.com/graphql")
+    assert client._headers["Content-Type"] == "application/json"
+    assert (
+        client._headers["Accept"]
+        == "application/graphql-response+json, application/json"
+    )
+    assert client._headers["Accept-Encoding"] == "gzip"

--- a/tests/test_httpx_transport.py
+++ b/tests/test_httpx_transport.py
@@ -252,14 +252,6 @@ async def test_httpx_transport_status_error_handling(
     assert excinfo.value.response.json == {"errors": [{"message": "Bad Request"}]}
 
 
-async def test_httpx_transport_coerce_value_async() -> None:
-    transport = HttpxTransport(endpoint="http://test.com")
-    serializer = DefaultSerializer()
-
-    assert transport._coerce_value(True, serializer) == 1
-    assert transport._coerce_value({"a": 1}, serializer) == '{"a":1}'
-
-
 async def test_httpx_transport_invalid_method_async() -> None:
     transport = HttpxTransport(endpoint="http://test")
     with pytest.raises(GraphQLClientException, match="Invalid method"):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -21,19 +21,45 @@ def test_request_container_init_string() -> None:
     assert id(container.request) != id(request)
 
 
+def test_request_container_init_string_overrides() -> None:
+    headers = {"Authorization": "Bearer token"}
+    operation = "operationName"
+    variables = {"foo": "bar"}
+    extensions = {"ext": "val"}
+    container = GraphQLRequestContainer(
+        request="{}",
+        headers=headers,
+        operation=operation,
+        variables=variables,
+        extensions=extensions,
+    )
+    assert isinstance(container.request, GraphQLRequest)
+    assert container.request.query == "{}"
+    assert container.request.headers == headers
+    assert container.request.operationName == operation
+    assert container.request.variables == variables
+    assert container.request.extensions == extensions
+
+
 def test_request_container_overrides() -> None:
     request = GraphQLRequest(query="{}")
     headers = {"Authorization": "Bearer token"}
     operation = "operationName"
     variables = {"foo": "bar"}
+    extensions = {"ext": "val"}
     container = GraphQLRequestContainer(
-        request=request, headers=headers, operation=operation, variables=variables
+        request=request,
+        headers=headers,
+        operation=operation,
+        variables=variables,
+        extensions=extensions,
     )
     assert container.request != request
     assert isinstance(container.request, GraphQLRequest)
     assert container.request.headers == headers
     assert container.request.operationName == operation
     assert container.request.variables == variables
+    assert container.request.extensions == extensions
 
 
 def test_request_payload() -> None:
@@ -57,6 +83,7 @@ def test_graphql_request_asdict() -> None:
         "query": "{ city { name } }",
         "operationName": "GetCity",
         "variables": {},
+        "extensions": {},
     }
     assert request.asdict() == expected_dict
 
@@ -76,3 +103,29 @@ def test_request_payload_extra() -> None:
     # Test payload with operation name
     req_op = GraphQLRequest(query="query Q { test }", operation="Q")
     assert req_op.payload()["operationName"] == "Q"
+
+    # Test payload with extensions
+    req_ext = GraphQLRequest(
+        query="query Q { test }",
+        operation="Q",
+        variables={"a": 1},
+        extensions={"persistedQuery": {"version": 1}},
+    )
+    assert req_ext.payload() == {
+        "query": "query Q { test }",
+        "operationName": "Q",
+        "variables": {"a": 1},
+        "extensions": {"persistedQuery": {"version": 1}},
+    }
+
+
+def test_request_copy_extensions() -> None:
+    req = GraphQLRequest(
+        query="{ test }",
+        extensions={"persistedQuery": {"version": 1}},
+    )
+    copied = req.copy(extensions={"extra": True})
+    assert copied.extensions == {
+        "persistedQuery": {"version": 1},
+        "extra": True,
+    }

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -63,7 +63,7 @@ async def test_aiohttp_transport_non_200_raises_exception(
     with pytest.raises(GraphQLRequestException) as excinfo:
         await transport.request(method="POST", request=request, serializer=serializer)
 
-    assert excinfo.value.response.json is None
+    assert excinfo.value.response.json == {}
 
 
 async def test_aiohttp_transport_close_session_user_owned(


### PR DESCRIPTION
**Summary**

I have updated the client and transport layer to comply with the standard GraphQL-over-HTTP specification:

* **Accept Header**: Added `Accept: application/graphql-response+json, application/json` to default client headers.
* **Extensions Support**: Added `extensions` support to `GraphQLRequest` and container objects, forwarding them across `query`, `post`, `get`, `query_data_as`, and `subscribe`.
* **GET Parameter Normalization**: Implemented `prepare_get_params` to serialize `variables` and `extensions` as JSON strings and cleanly omit empty/None values. Removed obsolete `_coerce_value` methods.
* **GraphQL-over-HTTP 4xx Handling**: Added `is_graphql_response` helper. HTTP 400/422 responses returning `Content-Type: application/graphql-response+json` with error payloads now return a `GraphQLResponse` with `.errors` populated instead of raising `GraphQLRequestException`.
* **Transport Consistency**: Guaranteed consistent dictionary response structure across both `AiohttpTransport` and `HttpxTransport`.

**Testing**
* Added `tests/test_graphql_over_http.py` covering GET parameter encoding, 400 response handling, and `extensions` propagation.
* Verified full test suite (`pytest`), static typing (`mypy`), linting/formatting (`pre-commit`), and tox factors (`tox -e aiohttp -e httpx`, `tox -e docs`).